### PR TITLE
Correção erro: invalid class type cast

### DIFF
--- a/Source/Core/ormbr.dml.generator.pas
+++ b/Source/Core/ormbr.dml.generator.pas
@@ -415,7 +415,9 @@ begin
       if LFor > 0 then
        Continue;
       LColumnName := ATableName + '.' + LPrimaryKey.Columns[LFor];
-      if AID.IsType<integer> then
+      if AID.IsType<Int64> then
+        Result := Result + LColumnName + ' = ' + IntToStr(AID.AsInt64)
+      else if AID.IsType<integer> then
         Result := Result + LColumnName + ' = ' + AID.AsType<string>
       else
         Result := Result + LColumnName + ' = ' + QuotedStr(AID.AsType<string>);


### PR DESCRIPTION
Correção para erro ao converter o valor do tipo Int64 para string.

O erro ocorria ao usar a função Find(const AID: Int64) da classe TContainerObjectSet utilizando as classes modelos abaixo, onde possui um propriedade do tipo UInt64

**Cenário do erro:**

IDE: Delphi 10.1 Berlin Update 2

**Classe modelo:**

TModelBaseORM = class(TPersistent)
  private
    FID: UInt64;
  public
    [Restrictions([NoUpdate, NotNull])]
    [Column('id', ftLargeint)]
    property id: UInt64 read FID write FID;

  end;

  TAuditModelORM = class(TModelBaseORM)
  private
    Fdata_criacao: nullable<TDateTime>;
    Fdata_alteracao: nullable<TDateTime>;
  public
    constructor Create; virtual;
    destructor Destroy; override;

    [Restrictions([NoUpdate])]
    [Column('data_criacao', ftDateTime)]
    property data_criacao: nullable<TDateTime> read Fdata_criacao write Fdata_criacao;

    [Restrictions([NoInsert])]
    [Column('data_alteracao', ftDateTime)]
    property data_alteracao: nullable<TDateTime> read Fdata_alteracao write Fdata_alteracao;
  end;






