### PR TITLE
mudando DisableStringTrim antes de ativar o clientdataset

### DIFF
--- a/Source/Dataset/ormbr.dataset.clientdataset.pas
+++ b/Source/Dataset/ormbr.dataset.clientdataset.pas
@@ -108,9 +108,9 @@ begin
   //
   if not FOrmDataSet.Active then
   begin
+     FOrmDataSet.DisableStringTrim := True;
      FOrmDataSet.CreateDataSet;
-     FOrmDataSet.LogChanges := False;
-     FOrmDataSet.DisableStringTrim := true;
+     FOrmDataSet.LogChanges := False;     
   end;
 end;
 


### PR DESCRIPTION
Quando passava no `FOrmDataSet.DisableStringTrim := True;` apresentava o erro ( ClientDataSet: Cannot perform this operation on an open dataset ).
Na linha `FOrmDataSet.CreateDataSet;` o ClientDataSet muda para Active := True.
A alternativa e mudar o DisableStringTrim antes do CreateDataSet.
