### PR TITLE
Corrigir erro de conversão de tipo de classe inválida e erro no cache de comandos

### DIFF
--- a/Source/Core/ormbr.dml.generator.absolutedb.pas
+++ b/Source/Core/ormbr.dml.generator.absolutedb.pas
@@ -94,8 +94,12 @@ function TDMLGeneratorAbsoluteDB.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     LCriteria.AST.Select
@@ -104,7 +108,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -119,8 +123,12 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     LCriteria.AST.Select
@@ -129,7 +137,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.ads.pas
+++ b/Source/Core/ormbr.dml.generator.ads.pas
@@ -97,8 +97,12 @@ function TDMLGeneratorADS.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     LCriteria.AST.Select
@@ -107,7 +111,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -122,8 +126,12 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     LCriteria.AST.Select
@@ -132,7 +140,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.elevatedb.pas
+++ b/Source/Core/ormbr.dml.generator.elevatedb.pas
@@ -108,8 +108,12 @@ function TDMLGeneratorElevateDB.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     LCriteria.AST.Select
@@ -118,7 +122,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -133,8 +137,12 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     LCriteria.AST.Select
@@ -143,7 +151,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.firebird.pas
+++ b/Source/Core/ormbr.dml.generator.firebird.pas
@@ -95,8 +95,12 @@ function TDMLGeneratorFirebird.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     LCriteria.AST.Select
@@ -105,7 +109,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -120,8 +124,12 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     LCriteria.AST.Select
@@ -130,7 +138,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.mssql.pas
+++ b/Source/Core/ormbr.dml.generator.mssql.pas
@@ -137,16 +137,20 @@ var
   LCriteria: ICriteria;
   LTable: TTableMapping;
   LOrderBy: string;
+  LKey: string;
 begin
   LTable := TMappingExplorer.GetMappingTable(AClass);
   LOrderBy := GetGeneratorOrderBy(AClass, LTable.Name, AID);
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     Result := LCriteria.AsString;
     if APageSize > -1 then
       Result := GetGeneratorSelect(LCriteria, LOrderBy);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Where
   Result := Result + GetGeneratorWhere(AClass, LTable.Name, AID);
@@ -160,14 +164,18 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     Result := LCriteria.AsString;
     if APageSize > -1 then
       Result := GetGeneratorSelect(LCriteria, AOrderBy);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.mysql.pas
+++ b/Source/Core/ormbr.dml.generator.mysql.pas
@@ -83,12 +83,16 @@ function TDMLGeneratorMySQL.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -106,12 +110,16 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.nexusdb.pas
+++ b/Source/Core/ormbr.dml.generator.nexusdb.pas
@@ -107,8 +107,12 @@ function TDMLGeneratorNexusDB.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     LCriteria.AST.Select
@@ -117,7 +121,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -132,8 +136,12 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     LCriteria.AST.Select
@@ -142,7 +150,7 @@ begin
                                                      .Columns
                                                      .Columns[0].Name;
     Result := GetGeneratorSelect(LCriteria, APageSize);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.oracle.pas
+++ b/Source/Core/ormbr.dml.generator.oracle.pas
@@ -97,12 +97,16 @@ function TDMLGeneratorOracle.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   if APageSize > -1 then
     Result := Format(SELECTROW, [Result]);
@@ -122,14 +126,18 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     Result := LCriteria.AsString;
     if APageSize > -1 then
       Result := Format(SELECTROW, [Result]);
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.pas
+++ b/Source/Core/ormbr.dml.generator.pas
@@ -389,6 +389,7 @@ var
   LColumnName: String;
   LFor: Integer;
   LScopeWhere: String;
+  LIdUInt64: UInt64;
 //  LID: string;
 begin
   Result := '';
@@ -397,7 +398,7 @@ begin
     Result := ' WHERE ' + LScopeWhere;
   if AID.IsType<UInt64> then
   begin
-    if AID.AsUInt64 = 0 then
+    if AID.TryAsType<UInt64>(LIdUInt64)  then
       Exit;
   end
   else
@@ -414,7 +415,7 @@ begin
   end
   else
   if AID.IsType<string> then
-  begin 
+  begin
     if AID.AsString = '-1' then
       Exit;
   end;

--- a/Source/Core/ormbr.dml.generator.pas
+++ b/Source/Core/ormbr.dml.generator.pas
@@ -389,7 +389,7 @@ var
   LColumnName: String;
   LFor: Integer;
   LScopeWhere: String;
-  LIdUInt64: UInt64;
+  LIntValue: Int64;
 //  LID: string;
 begin
   Result := '';
@@ -398,7 +398,7 @@ begin
     Result := ' WHERE ' + LScopeWhere;
   if AID.IsType<UInt64> then
   begin
-    if AID.TryAsType<UInt64>(LIdUInt64)  then
+    if AID.TryAsType<Int64>(LIntValue) and (LIntValue = -1)  then
       Exit;
   end
   else

--- a/Source/Core/ormbr.dml.generator.pas
+++ b/Source/Core/ormbr.dml.generator.pas
@@ -395,6 +395,18 @@ begin
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);
   if LScopeWhere <> '' then
     Result := ' WHERE ' + LScopeWhere;
+  if AID.IsType<UInt64> then
+  begin
+    if AID.AsUInt64 = 0 then
+      Exit;
+  end
+  else
+  if AID.IsType<Int64> then
+  begin
+    if AID.AsInt64 = -1 then
+      Exit;
+  end
+  else
   if AID.IsType<integer> then
   begin
     if AID.AsInteger = -1 then
@@ -415,9 +427,11 @@ begin
       if LFor > 0 then
        Continue;
       LColumnName := ATableName + '.' + LPrimaryKey.Columns[LFor];
-      if AID.IsType<Int64> then
+      if AID.IsType<UInt64> then
+        Result := Result + LColumnName + ' = ' + UIntToStr(AID.AsUInt64)
+      else if AID.IsType<Int64> then
         Result := Result + LColumnName + ' = ' + IntToStr(AID.AsInt64)
-      else if AID.IsType<integer> then
+      else if AID.IsType<Integer> then
         Result := Result + LColumnName + ' = ' + AID.AsType<string>
       else
         Result := Result + LColumnName + ' = ' + QuotedStr(AID.AsType<string>);

--- a/Source/Core/ormbr.dml.generator.postgresql.pas
+++ b/Source/Core/ormbr.dml.generator.postgresql.pas
@@ -82,12 +82,16 @@ function TDMLGeneratorPostgreSQL.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -105,12 +109,16 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);

--- a/Source/Core/ormbr.dml.generator.sqlite.pas
+++ b/Source/Core/ormbr.dml.generator.sqlite.pas
@@ -80,12 +80,16 @@ function TDMLGeneratorSQLite.GeneratorSelectAll(AClass: TClass;
 var
   LCriteria: ICriteria;
   LTable: TTableMapping;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, AID);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   LTable := TMappingExplorer.GetMappingTable(AClass);
   // Where
@@ -103,12 +107,16 @@ var
   LCriteria: ICriteria;
   LScopeWhere: String;
   LScopeOrderBy: String;
+  LKey: string;
 begin
-  if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
+  LKey := AClass.ClassName + '-SELECT';
+  if APageSize > -1 then
+    LKey := LKey + '-PAGINATE';
+  if not FQueryCache.TryGetValue(LKey, Result) then
   begin
     LCriteria := GetCriteriaSelect(AClass, -1);
     Result := LCriteria.AsString;
-    FQueryCache.AddOrSetValue(AClass.ClassName, Result);
+    FQueryCache.AddOrSetValue(LKey, Result);
   end;
   // Scope Where
   LScopeWhere := GetGeneratorQueryScopeWhere(AClass);


### PR DESCRIPTION
Correção para erro que estava ocorrendo ao usar o tipo UInt64 em propriedades de classe de modelo.

![image](https://github.com/user-attachments/assets/14c7aeeb-6435-4281-b103-92065f5f002a)

O erro ocorre numa aplicação Win64 utilizando Delphi 10.1 Berlin Version 24.0.25048.9432 utilizando o método find do da classe TContainerObjectSet,  talvez em versões mais recentes o erro não ocorra, isso teria que ser testado. Mas da forma que fiz a implementação resolve o problema da conversa e acredito que não gere impacto em outras versões de Delphi.

![image](https://github.com/user-attachments/assets/2a0b846b-2948-4c87-8095-992667bf720a)
